### PR TITLE
Fix NO ANSWER RETURNED issue

### DIFF
--- a/praeda.pl
+++ b/praeda.pl
@@ -272,7 +272,6 @@ else
 
  if ( defined $socket ) 
      {
-      sleep $WAIT_FOR_RST; 
       my $is_connected = $socket->connected;
 
          if ( defined $is_connected ) 


### PR DESCRIPTION
When attempting to scan a device I'm seeing a "NO ANSWER RETURNED" message even though the device is accessible. The behavior appears to be related to a sleep call in the check_port method after the socket is created. Removing the sleep appears to resolve the issue with the device I'm testing. Given the lack of comments I'm uncertain of the reason for the sleep call. Perhaps it is necessary for certain devices? I would suggest testing additional devices with this fix.
#### Before Fix

```
$ ./praeda.pl -t target.txt -p 80 -j test_project -l log_file
192.168.0.1:80:NO ANSWER RETURNED
```
#### After Fix

```
$ ./praeda.pl -t target.txt -p 80 -j test_project -l log_file
192.168.0.1:80:Residential Gateway Login:

**********Attempting to extract wifi settings via snmp from 192.168.0.1 : JOB MA0024**********
SUCCESS
```
